### PR TITLE
Add SmartSpeaker accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# homebridge-applescript-file-lightbulb
+# homebridge-applescript-file-speaker
 
-A homebridge lightbulb accessory that can trigger specific AppleScript files
+A homebridge speaker accessory that can trigger specific AppleScript files
 
 
 ## Installation
 
 1. Install homebridge using: `npm install -g homebridge`
-2. Install this plugin using: `npm install -g homebridge-applescript-file-lightbulb`
+2. Install this plugin using: `npm install -g homebridge-applescript-file-speaker`
 3. Update your configuration file. See `sample-config.json` in this repository for a sample.
 
 ## Configuration
@@ -16,17 +16,17 @@ Configuration sample:
 ```
 "accessories": [
     {
-        "accessory": "ApplescriptFileLightbulb",
-        "name": "iTunes Volume",
+        "accessory": "ApplescriptFileSpeaker",
+        "name": "iTunes Speaker",
         "on": "",
         "off": "",
-        "brightness": "/Users/bendodson/Documents/Scripts/musicVolume.applescript"
+        "volume": "/Users/bendodson/Documents/Scripts/musicVolume.applescript"
     }
 ]
 ```
 Note that you must use absolute paths for your AppleScript file.
 
-In this example I'm just using the "brightness" attribute in order to change the volume of iTunes although you can specify on / off states should you want to do something like pause or resume iTunes with the same accessory. An example of a volume control AppleScript is listed below:
+In this example the "volume" attribute is used to change the volume of iTunes although you can specify on / off states should you want to do something like pause or resume iTunes with the same accessory. An example of a volume control AppleScript is listed below:
 
 ```
 on run argv

--- a/config-sample.json
+++ b/config-sample.json
@@ -6,15 +6,15 @@
 		"pin": "031-45-154"
 	},
 
-	"description": "This is an example configuration for the Applescript File Lightbulb homebridge plugin",
+        "description": "This is an example configuration for the Applescript File Speaker homebridge plugin",
 
 	"accessories": [
-		{
-			"accessory": "ApplescriptFileLightbulb",
-			"name": "iTunes Volume",
-			"on": "",
-			"off": "",
-			"brightness": "/Users/bendodson/Documents/Scripts/musicVolume.applescript"
-		}
+                {
+                        "accessory": "ApplescriptFileSpeaker",
+                        "name": "iTunes Speaker",
+                        "on": "",
+                        "off": "",
+                        "volume": "/Users/bendodson/Documents/Scripts/musicVolume.applescript"
+                }
 	]
 }

--- a/index.js
+++ b/index.js
@@ -4,25 +4,25 @@ var Characteristic;
 var applescript = require('applescript');
 
 module.exports = function(homebridge) {
-	Service = homebridge.hap.Service;
-	Characteristic = homebridge.hap.Characteristic;
-	homebridge.registerAccessory('homebridge-applescript-file-lightbulb', 'ApplescriptFileLightbulb', ApplescriptAccessory);
+        Service = homebridge.hap.Service;
+        Characteristic = homebridge.hap.Characteristic;
+        homebridge.registerAccessory('homebridge-applescript-file-speaker', 'ApplescriptFileSpeaker', ApplescriptSpeakerAccessory);
 }
 
-function ApplescriptAccessory(log, config) {
-	this.log = log;
-	this.service = 'Switch';
-	this.name = config['name'];
-	this.onCommand = config['on'];
-	this.offCommand = config['off'];
-	this.brightnessCommand = config['brightness'];
+function ApplescriptSpeakerAccessory(log, config) {
+        this.log = log;
+        this.service = 'SmartSpeaker';
+        this.name = config['name'];
+        this.onCommand = config['on'];
+        this.offCommand = config['off'];
+        this.volumeCommand = config['volume'];
 }
 
-ApplescriptAccessory.prototype.setState = function(powerOn, callback) {
-	var accessory = this;
-	var state = powerOn ? 'on' : 'off';
-	var prop = state + 'Command';
-	var command = accessory[prop];
+ApplescriptSpeakerAccessory.prototype.setState = function(targetState, callback) {
+        var accessory = this;
+        var state = targetState === Characteristic.TargetMediaState.PLAY ? 'on' : 'off';
+        var prop = state + 'Command';
+        var command = accessory[prop];
 
 	if (command.length == 0) {
 		return;
@@ -41,9 +41,9 @@ ApplescriptAccessory.prototype.setState = function(powerOn, callback) {
 	}
 }
 
-ApplescriptAccessory.prototype.setBrightness = function(level, callback) {
-	var accessory = this;
-	var command = accessory['brightnessCommand'];
+ApplescriptSpeakerAccessory.prototype.setVolume = function(level, callback) {
+        var accessory = this;
+        var command = accessory['volumeCommand'];
 	if (command.length == 0) {
 		return;
 	}
@@ -61,22 +61,21 @@ ApplescriptAccessory.prototype.setBrightness = function(level, callback) {
 	}
 }
 
-ApplescriptAccessory.prototype.getServices = function() {
-	var informationService = new Service.AccessoryInformation();
-	var lightbulbService = new Service.Lightbulb(this.name);
+ApplescriptSpeakerAccessory.prototype.getServices = function() {
+        var informationService = new Service.AccessoryInformation();
+        var speakerService = new Service.SmartSpeaker(this.name);
 
 	informationService
 		.setCharacteristic(Characteristic.Manufacturer, 'Applescript Manufacturer')
 		.setCharacteristic(Characteristic.Model, 'Applescript Model')
 		.setCharacteristic(Characteristic.SerialNumber, 'Applescript Serial Number');
 
-	lightbulbService
-		.getCharacteristic(Characteristic.On)
-		.on('set', this.setState.bind(this));
+        speakerService
+                .getCharacteristic(Characteristic.TargetMediaState)
+                .on('set', this.setState.bind(this));
 
-	lightbulbService
-            .addCharacteristic(Characteristic.Brightness)
-            .on('set', this.setBrightness.bind(this));
-
-	return [lightbulbService];
+        speakerService
+            .getCharacteristic(Characteristic.Volume)
+            .on('set', this.setVolume.bind(this));
+        return [speakerService];
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "homebridge-applescript-file-lightbulb",
+        "name": "homebridge-applescript-file-speaker",
 	"version": "0.0.4",
 	"description": "Applescript plugin for homebridge: https://github.com/nfarina/homebridge",
 	"license": "ISC",
@@ -13,11 +13,11 @@
 	"author": {
 		"name": "Ben Dodson & Dan Budiac"
 	},
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/bendodson/homebridge-applescript-file-lightbulb.git"
-	},
-	"dependencies": {
-		"applescript": "0.2.1"
-	}
+        "repository": {
+                "type": "git",
+                "url": "git://github.com/bendodson/homebridge-applescript-file-speaker.git"
+        },
+        "dependencies": {
+                "applescript": "0.2.1"
+        }
 }


### PR DESCRIPTION
## Summary
- convert plugin registration to `homebridge-applescript-file-speaker`
- implement SmartSpeaker service with volume support
- update configuration example and README
- rename package to `homebridge-applescript-file-speaker`

## Testing
- `node -e "require('./index.js')"` *(fails: Cannot find module 'applescript')*
- `npm install --silent`
- `node -e "require('./index.js')"`

------
https://chatgpt.com/codex/tasks/task_e_687d3aae36ac8333b15fa77e848f7fec